### PR TITLE
add collborator to SpaceRelationships

### DIFF
--- a/src/app/models/space.ts
+++ b/src/app/models/space.ts
@@ -27,6 +27,7 @@ export class SpaceLink {
 export class SpaceRelationships {
     areas: SpaceRelatedLink;
     iterations: SpaceRelatedLink;
+    collaborators: SpaceRelatedLink;
     'owned-by': {
       data: {
         id: string;


### PR DESCRIPTION
fixes #82 
This would be consumed here : https://github.com/fabric8io/fabric8-planner/blob/master/src/app/collaborator/collaborator.service.ts#L24 as `relationships.collaborators.links.related`