### PR TITLE
fix(models): updated space and process template models

### DIFF
--- a/src/app/models/process-template.ts
+++ b/src/app/models/process-template.ts
@@ -2,7 +2,7 @@ export class ProcessTemplate {
   attributes: {
     'created-at': string;
     description: string;
-    isBaseTemplate: boolean;
+    'can-construct': boolean;
     name: string;
     'updated-at': string;
     version: number

--- a/src/app/models/process-template.ts
+++ b/src/app/models/process-template.ts
@@ -1,4 +1,27 @@
 export class ProcessTemplate {
-    name: string;
+  attributes: {
+    'created-at': string;
     description: string;
+    isBaseTemplate: boolean;
+    name: string;
+    'updated-at': string;
+    version: number
+  };
+  id: string;
+  links: {
+    self: string;
+  };
+  relationships: {
+    workitemlinktypes: {
+      links: {
+        related: string;
+      };
+    };
+    workitemtypegroups: {
+      links: {
+        related: string;
+      };
+    };
+  };
+  type: 'spacetemplates';
 }

--- a/src/app/models/space.ts
+++ b/src/app/models/space.ts
@@ -5,7 +5,6 @@ import { User } from "ngx-login-client";
 export interface Space {
     name: string;
     path: String;
-    process?: ProcessTemplate;
     privateSpace?: boolean;
     teams: Team[];
     defaultTeam: Team;
@@ -36,6 +35,16 @@ export class SpaceRelationships {
         type: string;
       };
     };
+    'space-template'?: {
+      data: {
+        id: string;
+        type: 'spacetemplates'
+      },
+      links?: {
+        related?: string;
+        self?: string;
+      }
+    }
 }
 
 export class SpaceRelatedLink {

--- a/src/app/models/space.ts
+++ b/src/app/models/space.ts
@@ -27,6 +27,7 @@ export class SpaceRelationships {
     areas: SpaceRelatedLink;
     iterations: SpaceRelatedLink;
     workitemtypegroups: SpaceRelatedLink;
+    workitemtypes?: SpaceRelatedLink;
     // this change breaks in fabric8-ui, fix it there to include this.
     //collaborators: SpaceRelatedLink;
     'owned-by': {

--- a/src/app/models/space.ts
+++ b/src/app/models/space.ts
@@ -1,6 +1,6 @@
+import { User } from 'ngx-login-client';
+
 import { Team } from './team';
-import { ProcessTemplate } from './process-template';
-import { User } from "ngx-login-client";
 
 export interface Space {
     name: string;


### PR DESCRIPTION
Process templates are served from the backend services with proper JSON API format (https://github.com/fabric8-services/fabric8-wit/pull/1148). Thus the data model of process template is updated in this PR.

Issue - https://github.com/fabric8-ui/ngx-fabric8-wit/issues/175