### PR TITLE
Update space name directives

### DIFF
--- a/src/app/spaces/unique-space-name.directive.spec.ts
+++ b/src/app/spaces/unique-space-name.directive.spec.ts
@@ -60,11 +60,6 @@ describe('Directive for Name Space', () => {
             related: 'http://example.com/api/spacetemplates/1/workitemtypegroups'
           }
         },
-        // collaborators: {
-        //   links: {
-        //     related: 'http://example.com/api/spaces/1/iterations'
-        //   }
-        // },
         'owned-by': {
           'data': {
             'id': '00000000-0000-0000-0000-000000000000',
@@ -95,7 +90,6 @@ describe('Directive for Name Space', () => {
   });
 
   it('Validate false when 2 spaces exist with same name', async(() => {
-    // given
     let user = {
       'attributes': {
         'fullName': 'name',
@@ -110,7 +104,6 @@ describe('Directive for Name Space', () => {
     spaceServiceSpy.getSpaceByName.and.returnValue(Observable.of(space));
 
 
-    let comp = fixture.componentInstance;
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
@@ -118,14 +111,12 @@ describe('Directive for Name Space', () => {
     fixture.detectChanges();
 
    fixture.whenStable().then(() => {
-     // when
       input.nativeElement.value = 'TestSpace';
       input.nativeElement.dispatchEvent( new Event('input'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         let form: NgForm = debug.children[0].injector.get(NgForm);
         let control = form.control.get('spaceName');
-        // then
         expect(control.hasError('unique')).toBe(true);
         expect(control.errors.unique.valid).toBeFalsy();
         expect(control.errors.unique.existingSpace.name).toEqual('TestSpace');

--- a/src/app/spaces/unique-space-name.directive.spec.ts
+++ b/src/app/spaces/unique-space-name.directive.spec.ts
@@ -71,6 +71,17 @@ describe('Directive for Name Space', () => {
             'type': 'identities'
           }
         }
+      },
+      relationalData: {
+        creator: {
+          attributes: {
+            fullName: 'name',
+            imageURL: 'url',
+            username: 'name'
+          },
+          id: 'id',
+          type: 'type'
+        }
       }
     };
     TestBed.configureTestingModule({

--- a/src/app/spaces/unique-space-name.directive.spec.ts
+++ b/src/app/spaces/unique-space-name.directive.spec.ts
@@ -120,6 +120,8 @@ describe('Directive for Name Space', () => {
         expect(control.hasError('unique')).toBe(true);
         expect(control.errors.unique.valid).toBeFalsy();
         expect(control.errors.unique.existingSpace.name).toEqual('TestSpace');
+        let expectedMessage = 'The Space Name TestSpace  is already in use as name/TestSpace';
+        expect(control.errors.unique.message).toEqual(expectedMessage);
       });
    });
   }));

--- a/src/app/spaces/unique-space-name.directive.ts
+++ b/src/app/spaces/unique-space-name.directive.ts
@@ -63,7 +63,14 @@ export function uniqueSpaceNameValidator(
           return spaceService
             .getSpaceByName(user.attributes.username, control.value ? control.value.replace(' ', '_') : control.value)
             .map(val => {
-              return { unique: { valid: false, existingSpace: val, requestedName: control.value } };
+              return {
+                unique: {
+                  valid: false,
+                  existingSpace: val,
+                  requestedName: control.value,
+                  message: `The Space Name ${control.value}  is already in use as ${val.relationalData.creator.attributes.username}/${val.attributes.name}`
+                }
+              };
             })
             .catch(val => {
               return Observable.of(null);

--- a/src/app/spaces/unique-space-name.directive.ts
+++ b/src/app/spaces/unique-space-name.directive.ts
@@ -58,7 +58,7 @@ export function uniqueSpaceNameValidator(
       .debounceTime(200)
       .distinctUntilChanged()
       .takeUntil(changed$)
-      .switchMap(value => userService.loggedInUser
+      .switchMap(() => userService.loggedInUser
         .switchMap(user => {
           return spaceService
             .getSpaceByName(user.attributes.username, control.value ? control.value.replace(' ', '_') : control.value)
@@ -72,7 +72,7 @@ export function uniqueSpaceNameValidator(
                 }
               };
             })
-            .catch(val => {
+            .catch(() => {
               return Observable.of(null);
             });
         }))

--- a/src/app/spaces/valid-space-name.directive.spec.ts
+++ b/src/app/spaces/valid-space-name.directive.spec.ts
@@ -1,5 +1,5 @@
 import { async, TestBed } from '@angular/core/testing';
-import { ValidSpaceNameValidatorDirective, validSpaceNameValidator } from './valid-space-name.directive'
+import { ValidSpaceNameValidatorDirective } from './valid-space-name.directive';
 import { FormsModule, NgForm } from '@angular/forms';
 import { Component } from '@angular/core';
 import { By } from '@angular/platform-browser';
@@ -27,7 +27,6 @@ describe('Directive for Name Space', () => {
   it('Validate false when name starts with unsupported characters', async(() => {
     // given
     let fixture = TestBed.createComponent(TestSpaceNameComponent);
-    let comp = fixture.componentInstance;
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
@@ -101,7 +100,6 @@ describe('Directive for Name Space', () => {
     it('Validate false when there is too many characters', async(() => {
     // given
     let fixture = TestBed.createComponent(TestSpaceNameComponent);
-    let comp = fixture.componentInstance;
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';

--- a/src/app/spaces/valid-space-name.directive.spec.ts
+++ b/src/app/spaces/valid-space-name.directive.spec.ts
@@ -16,7 +16,6 @@ class TestSpaceNameComponent {
 }
 
 describe('Directive for Name Space', () => {
-
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [FormsModule],
@@ -30,13 +29,13 @@ describe('Directive for Name Space', () => {
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
-    input.nativeElement.dispatchEvent( new Event('input'));
+    input.nativeElement.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-   fixture.whenStable().then(() => {
-     // when
+    fixture.whenStable().then(() => {
+      // when
       input.nativeElement.value = '_start2';
-      input.nativeElement.dispatchEvent( new Event('input'));
+      input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         let form: NgForm = debug.children[0].injector.get(NgForm);
@@ -44,8 +43,13 @@ describe('Directive for Name Space', () => {
         // then
         expect(control.hasError('invalid')).toBe(true);
         expect(control.errors.invalid.valid).toBeFalsy();
+        expect(control.errors.invalid.valid).toBeFalsy();
+        let expectedMessage =
+          'Space Name must contain only letters, numbers, underscores (_)' +
+          'or hyphens(-). It cannot start or end with an underscore or a hyphen';
+        expect(control.errors.invalid.message).toEqual(expectedMessage);
       });
-   });
+    });
   }));
 
   it('Validate false when name ends with unsupported characters', async(() => {
@@ -55,13 +59,13 @@ describe('Directive for Name Space', () => {
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
-    input.nativeElement.dispatchEvent( new Event('input'));
+    input.nativeElement.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
     fixture.whenStable().then(() => {
       // when
       input.nativeElement.value = 'start2_';
-      input.nativeElement.dispatchEvent( new Event('input'));
+      input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         let form: NgForm = debug.children[0].injector.get(NgForm);
@@ -69,6 +73,10 @@ describe('Directive for Name Space', () => {
         // then
         expect(control.hasError('invalid')).toBe(true);
         expect(control.errors.invalid.valid).toBeFalsy();
+        let expectedMessage =
+          'Space Name must contain only letters, numbers, underscores (_)' +
+          'or hyphens(-). It cannot start or end with an underscore or a hyphen';
+        expect(control.errors.invalid.message).toEqual(expectedMessage);
       });
     });
   }));
@@ -80,13 +88,13 @@ describe('Directive for Name Space', () => {
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
-    input.nativeElement.dispatchEvent( new Event('input'));
+    input.nativeElement.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-   fixture.whenStable().then(() => {
-     // when
+    fixture.whenStable().then(() => {
+      // when
       input.nativeElement.value = 'start_3';
-      input.nativeElement.dispatchEvent( new Event('input'));
+      input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         let form: NgForm = debug.children[0].injector.get(NgForm);
@@ -94,22 +102,23 @@ describe('Directive for Name Space', () => {
         // then
         expect(control.errors).toBeNull();
       });
-   });
+    });
   }));
 
-    it('Validate false when there is too many characters', async(() => {
+  it('Validate false when there are too many characters', async(() => {
     // given
     let fixture = TestBed.createComponent(TestSpaceNameComponent);
     let debug = fixture.debugElement;
     let input = debug.query(By.css('input'));
     input.nativeElement.value = 'start';
-    input.nativeElement.dispatchEvent( new Event('input'));
+    input.nativeElement.dispatchEvent(new Event('input'));
     fixture.detectChanges();
 
-   fixture.whenStable().then(() => {
-     // when
-      input.nativeElement.value = 's1234567890123456789012345678901234567890123456789012345678901234567890';
-      input.nativeElement.dispatchEvent( new Event('input'));
+    fixture.whenStable().then(() => {
+      // when
+      input.nativeElement.value =
+        's1234567890123456789012345678901234567890123456789012345678901234567890';
+      input.nativeElement.dispatchEvent(new Event('input'));
       fixture.detectChanges();
       fixture.whenStable().then(() => {
         let form: NgForm = debug.children[0].injector.get(NgForm);
@@ -117,10 +126,10 @@ describe('Directive for Name Space', () => {
         // then
         expect(control.hasError('maxLength')).toBe(true);
         expect(control.errors.maxLength.valid).toBeFalsy();
+        let expectedMessage =
+          'Space Name cannot be more than 63 characters long';
+        expect(control.errors.maxLength.message).toEqual(expectedMessage);
       });
-   });
+    });
   }));
-
 });
-
-

--- a/src/app/spaces/valid-space-name.directive.ts
+++ b/src/app/spaces/valid-space-name.directive.ts
@@ -50,7 +50,7 @@ export class ValidSpaceNameValidatorDirective implements Validator, OnChanges {
 export function validSpaceNameValidator(): AsyncValidatorFn {
 
   let changed$ = new Subject<any>();
-  let ALLOWED_SPACE_NAMES = /(^[a-z\d][a-z\d\s-_]*[a-z\d]$)|(^[a-z\d]$)/i;
+  let ALLOWED_SPACE_NAMES = /(^[a-z\d][a-z\d-_]*[a-z\d]$)|(^[a-z\d]$)/i;
 
   return (control: AbstractControl): Observable<{ [key: string]: any }> => {
     changed$.next();
@@ -65,6 +65,7 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
               valid: false,
               requestedName: control.value,
               max: ValidSpaceNameValidatorDirective.MAX_SPACE_NAME_LENGTH,
+              message: `Space Name cannot be more than ${ValidSpaceNameValidatorDirective.MAX_SPACE_NAME_LENGTH} characters long`
             }
           };
         }
@@ -74,7 +75,8 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
             minLength: {
               valid: false,
               requestedName: control.value,
-              min: ValidSpaceNameValidatorDirective.MIN_SPACE_NAME_LENGTH
+              min: ValidSpaceNameValidatorDirective.MIN_SPACE_NAME_LENGTH,
+              message: `Space Name must be at least ${ValidSpaceNameValidatorDirective.MIN_SPACE_NAME_LENGTH} characters long.`
             }
           };
         } else if (!strVal.match(ALLOWED_SPACE_NAMES)) {
@@ -82,7 +84,8 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
             invalid: {
               valid: false,
               requestedName: control.value,
-              allowedChars: ALLOWED_SPACE_NAMES
+              allowedChars: ALLOWED_SPACE_NAMES,
+              message: 'Space Name must contain only letters, numbers, underscores (_) or hyphens(-). It cannot start or end with an underscore or a hyphen'
             }
           };
         }

--- a/src/app/spaces/valid-space-name.directive.ts
+++ b/src/app/spaces/valid-space-name.directive.ts
@@ -58,7 +58,7 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
       .debounceTime(50)
       .distinctUntilChanged()
       .takeUntil(changed$)
-      .map(value => {
+      .map(() => {
         if (!control.value || control.value.toString().length > ValidSpaceNameValidatorDirective.MAX_SPACE_NAME_LENGTH) {
           return {
             maxLength: {
@@ -85,7 +85,9 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
               valid: false,
               requestedName: control.value,
               allowedChars: ALLOWED_SPACE_NAMES,
-              message: 'Space Name must contain only letters, numbers, underscores (_) or hyphens(-). It cannot start or end with an underscore or a hyphen'
+              message:
+                'Space Name must contain only letters, numbers, underscores (_)' +
+                'or hyphens(-). It cannot start or end with an underscore or a hyphen'
             }
           };
         }


### PR DESCRIPTION
This updates the space name directives with error messages so clients like fabric8-ui need not maintain them when changes occur. For example, if a restriction is changed, the error message in f8-ui would need to be altered in sync. If using these provided error messages, it would not need to do so. As well, spaces are disallowed from space names. This follows from recommendations in https://github.com/openshiftio/openshift.io/issues/3793 that I agree with. Along with this, there are some generic code cleaning changes.

There will be a follow-up patch to fabric8-ui to use these error messages and finish the work for https://github.com/openshiftio/openshift.io/issues/3793