### PR TITLE
fix(spaces): fix typo in error message

### DIFF
--- a/src/app/spaces/valid-space-name.directive.spec.ts
+++ b/src/app/spaces/valid-space-name.directive.spec.ts
@@ -45,8 +45,8 @@ describe('Directive for Name Space', () => {
         expect(control.errors.invalid.valid).toBeFalsy();
         expect(control.errors.invalid.valid).toBeFalsy();
         let expectedMessage =
-          'Space Name must contain only letters, numbers, underscores (_)' +
-          'or hyphens(-). It cannot start or end with an underscore or a hyphen';
+          'Space Name must contain only letters, numbers, underscores (_) ' +
+          'or hyphens (-). It cannot start or end with an underscore or a hyphen';
         expect(control.errors.invalid.message).toEqual(expectedMessage);
       });
     });
@@ -74,8 +74,8 @@ describe('Directive for Name Space', () => {
         expect(control.hasError('invalid')).toBe(true);
         expect(control.errors.invalid.valid).toBeFalsy();
         let expectedMessage =
-          'Space Name must contain only letters, numbers, underscores (_)' +
-          'or hyphens(-). It cannot start or end with an underscore or a hyphen';
+          'Space Name must contain only letters, numbers, underscores (_) ' +
+          'or hyphens (-). It cannot start or end with an underscore or a hyphen';
         expect(control.errors.invalid.message).toEqual(expectedMessage);
       });
     });

--- a/src/app/spaces/valid-space-name.directive.ts
+++ b/src/app/spaces/valid-space-name.directive.ts
@@ -86,8 +86,8 @@ export function validSpaceNameValidator(): AsyncValidatorFn {
               requestedName: control.value,
               allowedChars: ALLOWED_SPACE_NAMES,
               message:
-                'Space Name must contain only letters, numbers, underscores (_)' +
-                'or hyphens(-). It cannot start or end with an underscore or a hyphen'
+                'Space Name must contain only letters, numbers, underscores (_) ' +
+                'or hyphens (-). It cannot start or end with an underscore or a hyphen'
             }
           };
         }


### PR DESCRIPTION
This makes the spacing consistent. The source wasn't consistent before but I also managed to introduce an extra inconsistency myself. Sorry about that.